### PR TITLE
scylla_rest_client.py: log network requests

### DIFF
--- a/scylla_api_client/rest/scylla_rest_client.py
+++ b/scylla_api_client/rest/scylla_rest_client.py
@@ -1,7 +1,9 @@
+import logging
 from requests import Response
 
 from . import RestClient
 
+log = logging.getLogger('scylla.cli')
 
 class ScyllaRestClient(RestClient):
     def __init__(self, host: str = "localhost", port: str = "10000"):
@@ -13,12 +15,15 @@ class ScyllaRestClient(RestClient):
         return None
 
     def get(self, resource_path: str, query_params: dict = None):
+        log.debug(f"GET path: {resource_path}, params: {query_params}")
         return super().get(resource_path=resource_path, query_params=query_params)
 
     def post(self, resource_path: str, query_params: dict = None, json: dict = None):
+        log.debug(f"POST path: {resource_path}, params: {query_params}")
         return super().post(resource_path=resource_path, query_params=query_params, json=json)
 
     def delete(self, resource_path: str, query_params: dict = None):
+        log.debug(f"DELETE path: {resource_path}, params: {query_params}")
         return super().delete(resource_path=resource_path, query_params=query_params)
 
     def dispatch_rest_method(self, rest_method_kind: str, **kwargs) -> Response:


### PR DESCRIPTION
With debug level. Allows for fishing out the actual network requests made with debug logging enabled.