### PR TITLE
Add license keyword to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ setup(
             'scylla-api-client=scylla_api_client.__main__:main',
         ],
     },
+    license='GNU AGPL 3.0',
+    license_files=('LICENSE.AGPL',),
     classifiers=[
         'License :: OSI Approved :: GNU Affero General Public License v3 or later (AGPLv3+)',
     ],


### PR DESCRIPTION
The SBOM report generated for ScyllaDB doesn't recognize the license of scylla-api-client. This addition of the license keyword to the setup.py should add the information to the SBOM report

Ref https://github.com/scylladb/scylla-jmx/issues/237