### PR TITLE
Handle api warnings

### DIFF
--- a/scylla_api_client/api.py
+++ b/scylla_api_client/api.py
@@ -10,7 +10,7 @@ from pprint import PrettyPrinter
 
 from .rest.scylla_rest_client import ScyllaRestClient
 
-log = logging.getLogger('scylla.cli')
+log = logging.getLogger('scylla.api')
 
 """
 A dictionary that keeps the insertion order

--- a/scylla_api_client/api.py
+++ b/scylla_api_client/api.py
@@ -85,7 +85,7 @@ class ScyllaApiOption:
                  allowed_values=[], help:str='', path=None):
         self.name = name
         self.required = required
-        if (not ptype in ["array", "double", "boolean", "long", "string"]):
+        if (not ptype in ["array", "double", "boolean", "integer", "long", "string", "dict"]):
             log.warning(f"Unsupported option type {ptype} for operation {path} option {name}")
         self.type = ptype
         self.param_type = param_type
@@ -278,7 +278,7 @@ class ScyllaApiCommand:
             for param_def in operation_def["parameters"]:
                 method.add_option(ScyllaApiOption(param_def["name"],
                     required=param_def.get("required", False),
-                    ptype=param_def.get("type", None),
+                    ptype=param_def.get("type", param_def.get("schema", {"type": None})["type"]),
                     param_type=param_def.get("paramType", 'query'),
                     allowed_values=param_def.get("enum", []),
                     help=param_def["description"],

--- a/scylla_api_client/api.py
+++ b/scylla_api_client/api.py
@@ -82,11 +82,11 @@ class OrderedDict:
 class ScyllaApiOption:
     # init Command
     def __init__(self, name:str, required:bool = False, ptype:str=None, param_type:str='query',
-                 allowed_values=[], help:str=''):
+                 allowed_values=[], help:str='', path=None):
         self.name = name
         self.required = required
         if (not ptype in ["array", "double", "boolean", "long", "string"]):
-            log.warn(f"Unsupported option type {ptype} for option {name}")
+            log.warning(f"Unsupported option type {ptype} for operation {path} option {name}")
         self.type = ptype
         self.param_type = param_type
         if self.type == "boolean":
@@ -281,7 +281,8 @@ class ScyllaApiCommand:
                     ptype=param_def.get("type", None),
                     param_type=param_def.get("paramType", 'query'),
                     allowed_values=param_def.get("enum", []),
-                    help=param_def["description"]))
+                    help=param_def["description"],
+                    path=command_json["path"]))
             self.add_method(method)
 
     def invoke(self, node_address:str, port:int, argv=[], pretty_printer:PrettyPrinter=None):


### PR DESCRIPTION
We currently see some warnings coming from `ScyllaApiOption`:
https://github.com/scylladb/scylla-api-client/blob/67e26f559f9f89a83c49b1fc2bcdce80e19d3c06/scylla_api_client/api.py#L88-L89

We don't much with this type as far as syntax checking by the api-client tool as we let scylla do the checks, so this series just cleans up this path and expands the set of recognized types.